### PR TITLE
Support for Gzip + 304 handling

### DIFF
--- a/lib/tonic.php
+++ b/lib/tonic.php
@@ -798,7 +798,11 @@ class Response {
      * @codeCoverageIgnore
      */
     function output() {
-        if ($this->compress && $this->code != Response::NOTMODIFIED) {
+
+        if (
+            $this->compress &&
+            $this->code != Response::NOTMODIFIED
+           ) {
             ob_start("ob_gzhandler");
         }
         if (php_sapi_name() != 'cli' && !headers_sent()) {
@@ -809,7 +813,10 @@ class Response {
             }
         }
         
-        if (strtoupper($this->request->method) !== 'HEAD') {
+        if (
+            strtoupper($this->request->method) !== 'HEAD' &&
+            $this->code != Response::NOTMODIFIED
+           ) {
             echo $this->body;
         }
         


### PR DESCRIPTION
I've just added a `$compress` variable to the response that defaults to false.

If you set it to true, output gets gzipped.

304 as per http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html should not include a body, so I've added a conditional to make sure the response code isn't a 304 before echoing the body.
