### PR TITLE
The response does not work correctly, if 'body' property is set after the instance is constructed.

### DIFF
--- a/src/Tonic/Application.php
+++ b/src/Tonic/Application.php
@@ -282,7 +282,6 @@ class Application {
                 $parts = preg_split('/\s+/', $item);
                 if ($parts) {
                     $key = array_shift($parts);
-					$parts = array_filter($parts, function($i){return !empty($i);});
                     if (isset($data[$key])) {
                         $data[$key][] = trim(join(' ', $parts));
                     } else {


### PR DESCRIPTION
It might be better to only calculate length before it is about to be dumped.
