### PR TITLE
Make Response::responseMessage() protected

### DIFF
--- a/src/Tonic/Response.php
+++ b/src/Tonic/Response.php
@@ -97,7 +97,7 @@ class Response
      * Get the HTTP response message of this response
      * @return str
      */
-    private function responseMessage()
+    protected function responseMessage()
     {
         return isset($this->codes[$this->code]) ? $this->codes[$this->code] : '';
     }


### PR DESCRIPTION
Hi,

I'd like to propose making Response::responseMessage() protected in order to have the possibility to get message in extending classes.

See following gist for a usecase: https://gist.github.com/3124520

Thanks.
