### PR TITLE
Content type fix

### DIFF
--- a/src/Tonic/Request.php
+++ b/src/Tonic/Request.php
@@ -54,9 +54,9 @@ class Request
         $this->method = $this->getOption($options, 'method', 'REQUEST_METHOD', 'GET');
 
         if (isset($_SERVER['CONTENT_TYPE'])) {
-            list($this->contentType) = explode(';',$_SERVER['CONTENT_TYPE'],2);
+            $this->contentType = $_SERVER['CONTENT_TYPE'];
         } elseif (isset($_SERVER['HTTP_CONTENT_TYPE'])) {
-            list($this->contentType) = explode(';',$_SERVER['HTTP_CONTENT_TYPE'],2);
+            $this->contentType = $_SERVER['HTTP_CONTENT_TYPE'];
         }
 
         if (isset($_SERVER['CONTENT_LENGTH']) && $_SERVER['CONTENT_LENGTH'] > 0) {

--- a/src/Tonic/Resource.php
+++ b/src/Tonic/Resource.php
@@ -143,7 +143,7 @@ class Resource
      */
     protected function accepts($mimetype)
     {
-        if (strtolower($this->request->contentType) != strtolower($mimetype))
+        if (0 !== strpos(strtolower($this->request->contentType), strtolower($mimetype)))
             throw new UnsupportedMediaTypeException('No matching method for content type "'.$this->request->contentType.'"');
     }
 


### PR DESCRIPTION
- Allow for HTTP_CONTENT_TYPE header to set content type

Content type header set by PHP5.4 built in server is HTTP prefixed
- Use content-type as prefix

Content-type headers can have additional fields - use best possible match
so that method "accept" is more forgiving. Example:

Declared: @accept application/json
should match:
Sent: Content-type: application/json; charset=UTF-8
