### PR TITLE
Allow HTTP_CONTENT_LENGTH header

### DIFF
--- a/src/Tonic/Request.php
+++ b/src/Tonic/Request.php
@@ -98,7 +98,7 @@ class Request
 
     private function getData($options)
     {
-        if (isset($_SERVER['CONTENT_LENGTH']) && $_SERVER['CONTENT_LENGTH'] > 0) {
+        if ($this->getOption($options, 'contentLength', array('CONTENT_LENGTH', 'HTTP_CONTENT_LENGTH')) > 0) {
             return file_get_contents('php://input');
         } elseif (isset($options['data'])) {
             return $options['data'];


### PR DESCRIPTION
Same issue as before with contentType - this time contentLength. As before found with php5.4 built-in server.
