### PR TITLE
REQUEST_URI contains query string if present in request

### DIFF
--- a/src/Tonic/Request.php
+++ b/src/Tonic/Request.php
@@ -129,7 +129,7 @@ class Request
                 $dirname = dirname($_SERVER['SCRIPT_NAME']);
                 $uri = substr($_SERVER['REDIRECT_URL'], strlen($dirname == DIRECTORY_SEPARATOR ? '' : $dirname));
             } elseif (isset($_SERVER['REQUEST_URI'])) { // use request URI from environment
-                $uri = $_SERVER['REQUEST_URI'];
+                $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
             } elseif (isset($_SERVER['PHP_SELF']) && isset($_SERVER['SCRIPT_NAME'])) { // use PHP_SELF from Apache environment
                 $uri = substr($_SERVER['PHP_SELF'], strlen($_SERVER['SCRIPT_NAME']));
             } else { // fail


### PR DESCRIPTION
Hi again 
- this time a minor fix for resource uri discovery - REQUEST_URI contains query string if it was present in original request: http://host/path?query will result in "/path?query" in REQUEST_URI and this will rarely match any resource URI.
