### PR TITLE
Fix setting response code on FastCGI installations

### DIFF
--- a/src/Tonic/Response.php
+++ b/src/Tonic/Response.php
@@ -162,9 +162,8 @@ class Response
      */
     public function output()
     {
-        header('HTTP/1.1 '.$this->responseCode().' '.$this->responseMessage());
         foreach ($this->headers as $name => $value) {
-            header($name.': '.$value);
+            header($name.': '.$value, true, $this->responseCode());
         }
         echo $this->body;
     }


### PR DESCRIPTION
Status code on fastcgi deployments must be set by 'Status' not 'HTTP/' header. The
latter will always be dropped and will block setting 'Status'. It's also not possible
to detect reliably from source what type of deployment is used so the only way to
be sure proper status code is set is to use header's() 3rd param.
