### PR TITLE
Method name in before and after callbacks

### DIFF
--- a/src/Tonic/Resource.php
+++ b/src/Tonic/Resource.php
@@ -112,7 +112,7 @@ class Resource
 
         if (!$methodName) {
             throw new Exception;
-            
+
         } elseif (isset($resourceMetadata['methods'][$methodName]['response'])) {
             $response = Response::create($resourceMetadata['methods'][$methodName]['response']);
 
@@ -122,13 +122,13 @@ class Resource
         } else {
             if (isset($this->before[$methodName])) {
                 foreach ($this->before[$methodName] as $action) {
-                    $action($this->request);
+                    $action($this->request, $methodName);
                 }
             }
             $response = Response::create(call_user_func_array(array($this, $methodName), $this->params));
             if (isset($this->after[$methodName])) {
                 foreach ($this->after[$methodName] as $action) {
-                    $action($response);
+                    $action($response, $methodName);
                 }
             }
         }


### PR DESCRIPTION
Hey Paul,

I have a base Resource class (extended from Tonic\Resource) that all my resources extend from. I've decided to add @template annotation to my methods which would mean that response body in "after" callback should be passed to a template view and rendered.

So, in my BaseResource::template method i want to know the name of current method, to load its template, something like this:

``` php
    /**
     * Process @template annotation by loading template file, rendering it and
     * replacing response body with content
     * @return void
     */
    protected function template()
    {
        $app = $this->app;
        $className = explode('\\', get_class($this));
        $folder = strtolower(array_pop($className));

        $this->after(function($res, $methodName) use ($app) {
            if (is_array($res->body)) {
                $res->body = $app->services['view']->render("$methodName.twig", $res->body);
            }
        });
    }
```

I think someone would need the same functionality, so added additional parameter to before and after callbacks.
