### PR TITLE
Application factory method

### DIFF
--- a/src/Tonic/Resource.php
+++ b/src/Tonic/Resource.php
@@ -114,7 +114,7 @@ class Resource
             throw new Exception;
 
         } elseif (isset($resourceMetadata['methods'][$methodName]['response'])) {
-            $response = Response::create($resourceMetadata['methods'][$methodName]['response']);
+            $response = $this->app->factory('Response', $resourceMetadata['methods'][$methodName]['response']);
 
         } elseif (isset($methodPriorities[$methodName]['exception'])) {
             throw $methodPriorities[$methodName]['exception'];
@@ -125,7 +125,7 @@ class Resource
                     $action($this->request, $methodName);
                 }
             }
-            $response = Response::create(call_user_func_array(array($this, $methodName), $this->params));
+            $response = $this->app->factory('Response', call_user_func_array(array($this, $methodName), $this->params));
             if (isset($this->after[$methodName])) {
                 foreach ($this->after[$methodName] as $action) {
                     $action($response, $methodName);

--- a/src/Tonic/Response.php
+++ b/src/Tonic/Response.php
@@ -79,19 +79,21 @@ class Response
      * Factory method to create a Response from a variety of inputs
      *
      * @param mixed $response
+     * @return Response
      */
-    public static function create($response)
+    public static function factory($response)
     {
         if (is_array($response)) {
-            return new Response($response[0], $response[1]);
+            return new static($response[0], $response[1]);
         } elseif (is_int($response)) {
-            return new Response($response);
+            return new static($response);
         } elseif (is_string($response)) {
-            return new Response(200, $response);
-        } elseif ($response instanceof Response) {
+            return new static(static::OK, $response);
+        } elseif ($response instanceof static) {
             return $response;
         }
-        return new Response;
+
+        return new static;
     }
 
     /**


### PR DESCRIPTION
Hey Paul,

When working with Tonic, i found it difficult to extend some classes with my application-specific functionality (e.g. Response). So I decided to write a "smart" factory method for class instantiation. It accepts $className as first parameter, and all other passed parameters are forwarded to $className constructor (or factory method of $className, if it exists).

If $className does not include leading backslash, this method prepends current Application namespace to it, for instance:

``` php
// let's say $app is instance of Project\Application, which extends Tonic\Application
// here if Project\Response class exists, it will be loaded. Otherwise Tonic\Response is loaded
// $code and $body are passed to Response::factory method
$res = $app->factory('Response', $code, $body);
```

It makes every class loaded via Tonic\Application::factory easily substitutable, which is great if developer wants to add some methods to base Tonic classes.
