### PR TITLE
Handle multipart/form-data request content type

### DIFF
--- a/spec/DescribeTonicRequest.php
+++ b/spec/DescribeTonicRequest.php
@@ -8,6 +8,8 @@ class DescribeTonicRequest extends \PHPSpec\Context
     function after()
     {
         unset($_SERVER);
+        unset($_POST);
+        unset($_FILES);
     }
 
     private function createRequest($options = NULL)
@@ -150,4 +152,27 @@ class DescribeTonicRequest extends \PHPSpec\Context
         $this->spec($request->ifNoneMatch[1])->should->be('xyzzy');
     }
 
+    function itShouldHaveMultipartFormData()
+    {
+        $_POST['woo'] = 'yay';
+        $_FILES['foo'] = array(
+            'name' => 'bar.txt',
+            'type' => 'text/plain',
+            'tmp_name' => '/tmp/foobar',
+            'error' => 0,
+            'size' => 1234
+        );
+        $_SERVER['CONTENT_TYPE'] = 'multipart/form-data';
+        $request = $this->createRequest();
+        $this->spec($request->data)->should->be(array(
+            'woo' => 'yay',
+            'foo' => array(
+                'name' => 'bar.txt',
+                'type' => 'text/plain',
+                'tmp_name' => '/tmp/foobar',
+                'error' => 0,
+                'size' => 1234
+            )
+        ));
+    }
 }


### PR DESCRIPTION
In a multipart/form-data request, any part with a filename descriptor, PHP will put the data into a temp file and make it's metadata available via the $_FILES array; while putting other parts into the $_POST array.

This branch reconstructs the data as an array from the $_POST and $_FILES arrays.

@durilka
