### PR TITLE
Allow Resources with no URIs to be used

### DIFF
--- a/src/Tonic/Application.php
+++ b/src/Tonic/Application.php
@@ -101,8 +101,10 @@ class Application
     {
         foreach ($this->resources as $className => $metadata) {
             if ($metadata['namespace'][0] == $namespaceName) {
-                foreach ($metadata['uri'] as $index => $uri) {
-                    $this->resources[$className]['uri'][$index][0] = '|^'.$uriSpace.substr($uri[0], 2);
+                if (array_key_exists("uri", $metadata)) {
+                    foreach ($metadata['uri'] as $index => $uri) {
+                        $this->resources[$className]['uri'][$index][0] = '|^'.$uriSpace.substr($uri[0], 2);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Resources that don't have URIs (i have a "base" resource class that all my resources descend from to add authorization and other common functions) don't work due to the "url" key not existing in the metadata array

This patch fixes this. 
