### PR TITLE
use callables in before und after hooks

### DIFF
--- a/src/Tonic/Resource.php
+++ b/src/Tonic/Resource.php
@@ -122,13 +122,13 @@ class Resource
         } else {
             if (isset($this->before[$methodName])) {
                 foreach ($this->before[$methodName] as $action) {
-                    $action($this->request, $methodName);
+                    call_user_func($action, $this->request, $methodName);
                 }
             }
             $response = Response::create(call_user_func_array(array($this, $methodName), $this->params));
             if (isset($this->after[$methodName])) {
                 foreach ($this->after[$methodName] as $action) {
-                    $action($response, $methodName);
+                    call_user_func($action, $response, $methodName);
                 }
             }
         }


### PR DESCRIPTION
Currently may be called only the functions, which are acutally in the class hierarchy of `\Tonic\Resource`. It should be offered the opportunity to pass any function or class, not only the native functions. 
