### PR TITLE
Warning output when $headers not an array

### DIFF
--- a/src/Tonic/Response.php
+++ b/src/Tonic/Response.php
@@ -68,8 +68,10 @@ class Response
             $this->code = self::OK;
             $this->body = $code;
         }
-        foreach ($headers as $name => $value) {
-            $this->$name = $value;
+        if (is_array($headers)) {
+            foreach ($headers as $name => $value) {
+                $this->$name = $value;
+            }
         }
     }
 


### PR DESCRIPTION
Wrapped for loop in if statement so no warning would be issued if the $headers variable is not an array.
