### PR TITLE
Add mapping for svg file to Request class

### DIFF
--- a/src/Tonic/Request.php
+++ b/src/Tonic/Request.php
@@ -38,6 +38,7 @@ class Request
         'png' => 'image/png',
         'jpg' => 'image/jpeg',
         'ico' => 'image/x-icon',
+        'svg' => 'image/svg+xml',        
         'swf' => 'application/x-shockwave-flash',
         'flv' => 'video/x-flv',
         'avi' => 'video/mpeg',


### PR DESCRIPTION
Map 'svg' file/URI extension to 'image/svg+xml' mime type (in $mimetypes array of Request class)
