### PR TITLE
Fix PHP8 call_user_func_array breaking change

### DIFF
--- a/src/Tonic/Resource.php
+++ b/src/Tonic/Resource.php
@@ -147,7 +147,7 @@ class Resource
                     }
                 }
             }
-            $response = Response::create(call_user_func_array(array($this, $methodName), $this->params));
+            $response = Response::create(call_user_func_array(array($this, $methodName), array_filter($this->params, fn ($key) => is_numeric($key), ARRAY_FILTER_USE_KEY)));
             foreach (array('*', $methodName) as $mn) {
                 if (isset($this->after[$mn])) {
                     foreach ($this->after[$mn] as $action) {


### PR DESCRIPTION
Beginning with PHP 8, "args keys will now be interpreted as parameter names, instead of being silently ignored." https://www.php.net/manual/en/function.call-user-func-array.php

This solution effectively ignores named parameters in PHP8 by filtering out any named parameters. Not ideal, but it seems to work -- open to better ideas!